### PR TITLE
feat: simplify new chat button and dynamic frontend port selection

### DIFF
--- a/CHATVOTE-FrontEnd/src/components/chat/create-new-chat-dropdown-button-trigger.tsx
+++ b/CHATVOTE-FrontEnd/src/components/chat/create-new-chat-dropdown-button-trigger.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@components/ui/button";
-import { DropdownMenuTrigger } from "@components/ui/dropdown-menu";
 import { useSidebar } from "@components/ui/sidebar";
 import {
   Tooltip,
@@ -24,16 +23,14 @@ function CreateNewChatDropdownButtonTrigger({ onTriggerClick }: Props) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <DropdownMenuTrigger asChild>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="size-8"
-            onClick={onTriggerClick}
-          >
-            <SquarePenIcon />
-          </Button>
-        </DropdownMenuTrigger>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="size-8"
+          onClick={onTriggerClick}
+        >
+          <SquarePenIcon />
+        </Button>
       </TooltipTrigger>
       <TooltipContent>{t("createNewChat")}</TooltipContent>
     </Tooltip>

--- a/CHATVOTE-FrontEnd/src/components/chat/create-new-chat-dropdown-button.tsx
+++ b/CHATVOTE-FrontEnd/src/components/chat/create-new-chat-dropdown-button.tsx
@@ -1,44 +1,22 @@
 "use client";
 
-import { useState } from "react";
+import { useRouter } from "next/navigation";
 
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-} from "@components/ui/dropdown-menu";
-import { useTranslations } from "next-intl";
-
-import PartyCards from "../party-cards";
+import { useChatStore } from "@components/providers/chat-store-provider";
 
 import CreateNewChatDropdownButtonTrigger from "./create-new-chat-dropdown-button-trigger";
 
 function CreateNewChatDropdownButton() {
-  const t = useTranslations("common");
-  const [open, setOpen] = useState(false);
+  const router = useRouter();
+  const newChat = useChatStore((store) => store.newChat);
+
+  const handleClick = () => {
+    newChat();
+    router.push("/chat");
+  };
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <CreateNewChatDropdownButtonTrigger
-        onTriggerClick={() => setOpen(true)}
-      />
-      <DropdownMenuContent
-        align="end"
-        className="w-[80vw] max-w-[300px] bg-surface p-3"
-      >
-        <div className="mb-2 flex flex-col">
-          <h2 className="text-lg font-bold">{t("newChat")}</h2>
-          <p className="text-muted-foreground text-sm">{t("createNewChat")}</p>
-        </div>
-        <PartyCards
-          gridColumns={3}
-          selectable={false}
-          onSelectParty={() => {
-            setOpen(false);
-          }}
-          showChatvoteButton={true}
-        />
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <CreateNewChatDropdownButtonTrigger onTriggerClick={handleClick} />
   );
 }
 

--- a/CHATVOTE-FrontEnd/src/lib/stores/actions/new-chat.ts
+++ b/CHATVOTE-FrontEnd/src/lib/stores/actions/new-chat.ts
@@ -12,6 +12,9 @@ export const newChat: ChatStoreActionHandlerFor<"newChat"> =
       error: undefined,
       currentQuickReplies: [],
       currentChatTitle: undefined,
+      municipalityCode: undefined,
+      scope: "national",
+      selectedElectoralLists: [],
     });
 
     trackNewChatStarted({


### PR DESCRIPTION
## Summary
Two improvements to the ChatVote frontend and build process:

1. **Dynamic frontend port selection** — The `make setup` and `make dev` commands now dynamically select an available port instead of hardcoding port 3000. This prevents conflicts when multiple instances are running.

2. **Simplify new chat button** — Replaced the dropdown UI pattern with direct navigation, improving UX and reducing complexity.

## Changes
- Makefile: Updated setup and dev targets to use dynamic port selection
- scripts/setup.sh: Added logic to find available ports
- Frontend: Refactored new chat button component from dropdown to direct navigation
- Store: Updated new-chat action handler

## Related Commits
- 991c382: feat: dynamic frontend port selection in make setup and make dev
- 0747474: feat: simplify new chat button — replace dropdown with direct navigation