### PR TITLE
feat(analytics): consolidate tracking on Firebase → GA4, remove double-tag

### DIFF
--- a/CHATVOTE-FrontEnd/src/app/layout.tsx
+++ b/CHATVOTE-FrontEnd/src/app/layout.tsx
@@ -11,7 +11,6 @@ import { getTenant } from "@lib/firebase/firebase-admin";
 import { getAuth, getParties } from "@lib/firebase/firebase-server";
 import { getTheme } from "@lib/theme/getTheme";
 import { getAppUrl } from "@lib/url";
-import { GoogleAnalytics } from "@next/third-parties/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 
@@ -170,7 +169,6 @@ export default async function RootLayout({
           </AppProvider>
         </NextIntlClientProvider>
       </body>
-      <GoogleAnalytics gaId={config.googleAnalytics.gaId} />
     </html>
   );
 }

--- a/CHATVOTE-FrontEnd/src/components/anonymous-auth.tsx
+++ b/CHATVOTE-FrontEnd/src/components/anonymous-auth.tsx
@@ -13,6 +13,7 @@ import {
   getUser,
   updateUserData as updateUserDataFirebase,
 } from "@lib/firebase/firebase";
+import { setAnalyticsUserId, setAnalyticsUserProperties } from "@lib/firebase/analytics";
 import { type Auth, type User } from "@lib/types/auth";
 import { signInAnonymously } from "firebase/auth";
 import { useTranslations } from "next-intl";
@@ -83,6 +84,18 @@ export const AuthProvider = ({ children, initialAuth }: AuthProviderProps) => {
           isAnonymous: firebaseUser.isAnonymous,
           emailVerified: firebaseUser.emailVerified,
         });
+
+        // Track user identity for all auth types (including anonymous)
+        setAnalyticsUserId(firebaseUser.uid);
+        const providerId = firebaseUser.providerData[0]?.providerId;
+        const userType = firebaseUser.isAnonymous
+          ? "anonymous"
+          : providerId === "google.com"
+            ? "google"
+            : providerId === "microsoft.com"
+              ? "microsoft"
+              : "email";
+        setAnalyticsUserProperties({ user_type: userType });
 
         setUser((currentUser) => ({
           uid: firebaseUser.uid,

--- a/CHATVOTE-FrontEnd/src/components/auth/success-auth-form.tsx
+++ b/CHATVOTE-FrontEnd/src/components/auth/success-auth-form.tsx
@@ -2,8 +2,8 @@
 
 import { useAnonymousAuth } from "@components/anonymous-auth";
 import { Button } from "@components/ui/button";
+import { trackNewsletterSubscribed, trackNewsletterUnsubscribed } from "@lib/firebase/analytics";
 import { userAllowNewsletter } from "@lib/firebase/firebase";
-import { track } from "@vercel/analytics/react";
 import { HeartHandshakeIcon, XIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -17,7 +17,7 @@ const SuccessAuthForm = ({ onSuccess }: Props) => {
   const { user } = useAnonymousAuth();
 
   const handleSubscribe = async () => {
-    track("newsletter_subscribe");
+    trackNewsletterSubscribed();
     if (user) {
       await userAllowNewsletter(user.uid, true);
     }
@@ -26,7 +26,7 @@ const SuccessAuthForm = ({ onSuccess }: Props) => {
   };
 
   const handleUnsubscribe = async () => {
-    track("newsletter_unsubscribe");
+    trackNewsletterUnsubscribed();
 
     if (user) {
       await userAllowNewsletter(user.uid, false);

--- a/CHATVOTE-FrontEnd/src/components/chat/chat-message-like-dislike-buttons.tsx
+++ b/CHATVOTE-FrontEnd/src/components/chat/chat-message-like-dislike-buttons.tsx
@@ -1,10 +1,10 @@
 "use client";
 import { useChatStore } from "@components/providers/chat-store-provider";
 import { Button } from "@components/ui/button";
+import { trackFeedbackGiven } from "@lib/firebase/analytics";
 import { type StreamingMessage } from "@lib/socket.types";
 import { type MessageItem } from "@lib/stores/chat-store.types";
 import { cn } from "@lib/utils";
-import { track } from "@vercel/analytics/react";
 import { ThumbsUp } from "lucide-react";
 
 import ChatDislikeFeedbackButton from "./chat-dislike-feedback-button";
@@ -17,18 +17,13 @@ function ChatMessageLikeDislikeButtons({ message }: Props) {
   const setMessageFeedback = useChatStore((state) => state.setMessageFeedback);
 
   const handleLike = () => {
-    track("message_liked", {
-      message: message.content ?? "empty-message",
-    });
+    trackFeedbackGiven({ session_id: message.id, message_id: message.id, sentiment: "like" });
     setMessageFeedback(message.id, { feedback: "like" });
   };
 
   const handleDislikeFeedback = (details: string) => {
     setMessageFeedback(message.id, { feedback: "dislike", detail: details });
-    track("message_disliked", {
-      message: message.content ?? "empty-message",
-      details,
-    });
+    trackFeedbackGiven({ session_id: message.id, message_id: message.id, sentiment: "dislike" });
   };
 
   const isLiked = message.feedback?.feedback === "like";

--- a/CHATVOTE-FrontEnd/src/components/chat/copy-button.tsx
+++ b/CHATVOTE-FrontEnd/src/components/chat/copy-button.tsx
@@ -3,8 +3,8 @@
 import { useState } from "react";
 
 import { Button } from "@components/ui/button";
+import { trackMessageCopied } from "@lib/firebase/analytics";
 import { cn } from "@lib/utils";
-import { track } from "@vercel/analytics/react";
 import { type VariantProps } from "class-variance-authority";
 import { Check, Copy } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -36,9 +36,7 @@ function CopyButton({
     setIsCopied(true);
     toast.success(t("success"));
 
-    track("message_copied", {
-      message: text,
-    });
+    trackMessageCopied({ session_id: text.slice(0, 50) });
 
     setTimeout(() => {
       setIsCopied(false);

--- a/CHATVOTE-FrontEnd/src/components/donation-form.tsx
+++ b/CHATVOTE-FrontEnd/src/components/donation-form.tsx
@@ -4,9 +4,9 @@ import { useState } from "react";
 
 import { createCheckoutSession } from "@lib/server-actions/stripe-create-session";
 import { formatAmountForDisplay } from "@lib/stripe/stripe-helpers";
+import { trackDonationStarted } from "@lib/firebase/analytics";
 import { cn } from "@lib/utils";
 import NumberFlow from "@number-flow/react";
-import { track } from "@vercel/analytics/react";
 import { EqualIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -31,9 +31,7 @@ const DonationForm = () => {
   const [customAmount, setCustomAmount] = useState(false);
 
   const handleDonate = async (data: FormData) => {
-    track("donation_started", {
-      amount: amount,
-    });
+    trackDonationStarted({ amount });
 
     const result = await createCheckoutSession(data);
 

--- a/CHATVOTE-FrontEnd/src/components/providers/socket-provider.tsx
+++ b/CHATVOTE-FrontEnd/src/components/providers/socket-provider.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 
 import { type Locale } from "@i18n/config";
 import ChatSocket from "@lib/chat-socket";
+import { trackChatResponseReceived } from "@lib/firebase/analytics";
 import {
   type CandidateProConPerspectiveReadyPayload,
   type ChatSessionInitializedPayload,
@@ -154,6 +155,12 @@ function SocketProvider({ children }: Props) {
         data.party_id,
         data.complete_message,
       );
+      trackChatResponseReceived({
+        session_id: data.session_id,
+        party_id: data.party_id,
+        response_length: data.complete_message?.length ?? 0,
+        has_sources: false,
+      });
     }
 
     function onQuickRepliesAndTitleReady(

--- a/CHATVOTE-FrontEnd/src/config/index.ts
+++ b/CHATVOTE-FrontEnd/src/config/index.ts
@@ -1,7 +1,4 @@
 export const config = {
-  googleAnalytics: {
-    gaId: "G-9BFRV4Z8KN",
-  },
   websiteUrl: "https://chatvote.org",
   contactEmail: "contact@chatvote.org",
 };

--- a/CHATVOTE-FrontEnd/src/lib/firebase/analytics.ts
+++ b/CHATVOTE-FrontEnd/src/lib/firebase/analytics.ts
@@ -114,6 +114,8 @@ export function trackCommunePageView(params: {
     commune_code: params.commune_code,
     commune_name: params.commune_name,
   });
+  // Persist last visited commune as a user-level property
+  setAnalyticsUserProperties({ last_commune_code: params.commune_code });
 }
 
 export function trackElectoralListSelected(params: {
@@ -241,5 +243,89 @@ export function trackNewChatStarted(params: {
   trackEvent("new_chat_started", {
     scope: params.scope,
     party_count: params.party_count,
+  });
+}
+
+export function trackChatResponseReceived(params: {
+  session_id: string;
+  party_id: string;
+  response_length: number;
+  has_sources: boolean;
+}): void {
+  trackEvent("chat_response_received", {
+    session_id: params.session_id,
+    party_id: params.party_id,
+    response_length: params.response_length,
+    has_sources: params.has_sources ? 1 : 0,
+  });
+}
+
+export function trackErrorOccurred(params: {
+  error_type: string;
+  error_context?: string;
+}): void {
+  trackEvent("app_error", {
+    error_type: params.error_type,
+    ...(params.error_context ? { error_context: params.error_context } : {}),
+  });
+}
+
+export function trackFeedbackGiven(params: {
+  session_id: string;
+  message_id: string;
+  sentiment: "like" | "dislike";
+}): void {
+  trackEvent("feedback_given", {
+    session_id: params.session_id,
+    message_id: params.message_id,
+    sentiment: params.sentiment,
+  });
+}
+
+export function trackMessageCopied(params: {
+  session_id: string;
+  party_id?: string;
+}): void {
+  trackEvent("message_copied", {
+    session_id: params.session_id,
+    ...(params.party_id ? { party_id: params.party_id } : {}),
+  });
+}
+
+export function trackDonationStarted(params: {
+  amount: number;
+}): void {
+  trackEvent("donation_started", {
+    amount: params.amount,
+  });
+}
+
+export function trackNewsletterSubscribed(): void {
+  trackEvent("newsletter_subscribe");
+}
+
+export function trackNewsletterUnsubscribed(): void {
+  trackEvent("newsletter_unsubscribe");
+}
+
+export function trackSecondTourModeViewed(params: {
+  commune_code: string;
+  mode: "second_tour" | "elected_first_round";
+}): void {
+  trackEvent("second_tour_mode_viewed", {
+    commune_code: params.commune_code,
+    mode: params.mode,
+  });
+}
+
+export function trackCandidateSelectionChanged(params: {
+  commune_code: string;
+  candidate_id: string;
+  action: "added" | "removed";
+}): void {
+  trackEvent("candidate_selection_changed", {
+    commune_code: params.commune_code,
+    candidate_id: params.candidate_id,
+    action: params.action,
   });
 }

--- a/CHATVOTE-FrontEnd/src/lib/stores/actions/chat-add-user-message.ts
+++ b/CHATVOTE-FrontEnd/src/lib/stores/actions/chat-add-user-message.ts
@@ -2,7 +2,7 @@ import {
   addUserMessageToChatSession,
   createChatSession,
 } from "@lib/firebase/firebase";
-import { trackChatMessageSent } from "@lib/firebase/analytics";
+import { trackChatMessageSent, trackErrorOccurred } from "@lib/firebase/analytics";
 import { chatViewScrollToBottom } from "@lib/scroll-utils";
 import { type ChatStoreActionHandlerFor } from "@lib/stores/chat-store.types";
 import { generateUuid } from "@lib/utils";
@@ -28,7 +28,7 @@ export const chatAddUserMessage: ChatStoreActionHandlerFor<"addUserMessage"> =
         set((state) => {
           state.initialQuestionError = message;
         });
-
+      trackErrorOccurred({ error_type: "socket_disconnected" });
       return;
     }
 
@@ -146,7 +146,10 @@ export const chatAddUserMessage: ChatStoreActionHandlerFor<"addUserMessage"> =
       chatViewScrollToBottom();
     } catch (error) {
       console.error(error);
-
+      trackErrorOccurred({
+        error_type: "message_failed",
+        error_context: error instanceof Error ? error.message : undefined,
+      });
       set((state) => {
         state.loading.newMessage = false;
         state.error = "Failed to get chat answer";

--- a/CHATVOTE-FrontEnd/src/lib/stores/actions/set-socket-error.ts
+++ b/CHATVOTE-FrontEnd/src/lib/stores/actions/set-socket-error.ts
@@ -1,8 +1,13 @@
+import { trackErrorOccurred } from "@lib/firebase/analytics";
 import { type ChatStoreActionHandlerFor } from "@lib/stores/chat-store.types";
 
 export const setSocketError: ChatStoreActionHandlerFor<"setSocketError"> =
   (get, set) => (error) => {
     set((state) => {
       state.socket.error = error;
+    });
+    trackErrorOccurred({
+      error_type: "socket_error",
+      error_context: typeof error === "string" ? error : undefined,
     });
   };


### PR DESCRIPTION
## Résumé

Refactoring analytics complet — passage d'une triple stack fragmentée (Firebase Analytics + `@next/third-parties/google` + Vercel Analytics) à un **source unique Firebase → GA4**.

### Problèmes résolus
- **Double-tag GA4** : `<GoogleAnalytics gaId="G-9BFRV4Z8KN">` chargeait gtag.js en doublon avec Firebase Analytics → 2 hits `page_view` par visite. Supprimé.
- **Fragmentation des événements** : les actions utilisateurs (like, dislike, copie, don, newsletter) étaient trackées dans Vercel Analytics, invisible dans GA4. Migrés sur Firebase.
- **Customer journey incomplet** : aucun tracking des réponses IA, des erreurs socket, ni des propriétés utilisateur (type d'auth, commune visitée).

### Changements

#### `src/app/layout.tsx` + `src/config/index.ts`
- Supprime `<GoogleAnalytics>` et la clé `googleAnalytics.gaId`

#### `src/lib/firebase/analytics.ts`
Ajout de 9 nouvelles fonctions :
| Fonction | Événement GA4 |
|---|---|
| `trackChatResponseReceived` | `chat_response_received` |
| `trackErrorOccurred` | `app_error` |
| `trackFeedbackGiven` | `feedback_given` |
| `trackMessageCopied` | `message_copied` |
| `trackDonationStarted` | `donation_started` |
| `trackNewsletterSubscribed/Unsubscribed` | `newsletter_subscribe/unsubscribe` |
| `trackSecondTourModeViewed` | `second_tour_mode_viewed` |
| `trackCandidateSelectionChanged` | `candidate_selection_changed` |

#### Composants UI (migration Vercel → Firebase)
- `chat-message-like-dislike-buttons.tsx` → `trackFeedbackGiven`
- `copy-button.tsx` → `trackMessageCopied`
- `donation-form.tsx` → `trackDonationStarted`
- `success-auth-form.tsx` → `trackNewsletterSubscribed/Unsubscribed`

#### Instrumentation erreurs
- `socket-provider.tsx` → `trackChatResponseReceived` après chaque réponse complète
- `set-socket-error.ts` + `chat-add-user-message.ts` → `trackErrorOccurred`

#### Propriétés utilisateur
- `anonymous-auth.tsx` : `setAnalyticsUserId` + `user_type` pour **tous** les types d'auth (anonyme inclus, pas seulement email/OAuth)
- `analytics.ts` : `trackCommunePageView` persiste `last_commune_code` en user property

## Plan de test

- [ ] `npm run type:check` — aucune erreur TypeScript ✅ (vérifié)
- [ ] Ouvrir `app.chatvote.org` → DevTools Network → filtrer `collect?v=2` → vérifier **1 seul hit** par `page_view` (plus de double-tag)
- [ ] GA4 DebugView → déclencher une session chat → vérifier `chat_response_received`, `chat_message_sent`, `user_type=anonymous`
- [ ] Cliquer "Don" → vérifier `donation_started` dans DebugView
- [ ] Cliquer like/dislike → vérifier `feedback_given` avec `sentiment=like/dislike`

## Console GA4 — actions post-déploiement

Après merge, marquer ces 3 nouveaux événements comme **événements clés ⭐** dans `chat-vote-prod` → Admin → Événements :
- `donation_started`
- `newsletter_subscribe`
- `sign_up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)